### PR TITLE
Introduce default connection timeouts for crl fetcher

### DIFF
--- a/src/main/java/network/oxalis/commons/certvalidator/util/SimpleCachingCrlFetcher.java
+++ b/src/main/java/network/oxalis/commons/certvalidator/util/SimpleCachingCrlFetcher.java
@@ -5,7 +5,9 @@ import network.oxalis.commons.certvalidator.api.CrlCache;
 import network.oxalis.commons.certvalidator.api.CrlFetcher;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.net.URLConnection;
 import java.security.cert.CRLException;
 import java.security.cert.X509CRL;
 
@@ -51,7 +53,11 @@ public class SimpleCachingCrlFetcher implements CrlFetcher {
 
     protected X509CRL httpDownload(String url) throws CertificateValidationException {
         try {
-            return CrlUtils.load(URI.create(url).toURL().openStream());
+            URLConnection urlConnection = URI.create(url).toURL().openConnection();
+            urlConnection.setConnectTimeout(30000);
+            urlConnection.setReadTimeout(30000);
+            InputStream inputStream = urlConnection.getInputStream();
+            return CrlUtils.load(inputStream);
         } catch (IOException | CRLException e) {
             throw new CertificateValidationException(String.format("Failed to download CRL '%s' (%s)", url, e.getMessage()), e);
         }

--- a/src/test/java/network/oxalis/commons/certvalidator/util/SimpleCachingCrlFetcherTest.java
+++ b/src/test/java/network/oxalis/commons/certvalidator/util/SimpleCachingCrlFetcherTest.java
@@ -7,8 +7,16 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.net.ServerSocket;
 import java.security.cert.X509CRL;
 import java.util.Date;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
 
 public class SimpleCachingCrlFetcherTest {
 
@@ -54,4 +62,57 @@ public class SimpleCachingCrlFetcherTest {
 
         crlFetcher.get(null);
     }
+
+    @Test(enabled = false, expectedExceptions = CertificateValidationException.class)
+    public void testNonAccessibleHttpCert() throws Exception {
+        try {
+            NoResponseHttpServer.start();
+            CrlFetcher crlFetcher = new SimpleCachingCrlFetcher(new SimpleCrlCache());
+            crlFetcher.get("http://127.0.0.1:" + NoResponseHttpServer.getPort() + "/idontexist");
+        } finally {
+            NoResponseHttpServer.stop();
+        }
+    }
+
+    static class NoResponseHttpServer {
+
+        private static HttpServer server;
+
+        public static void start() throws IOException {
+            int port = getRandomAvailablePort();
+            server = HttpServer.create(new InetSocketAddress(port), 0);
+            server.createContext("/", new NoResponseHandler());
+            server.start();
+        }
+
+        public static void stop() {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
+
+        public static int getPort() {
+            if (server == null) {
+                return -1;
+            }
+            return server.getAddress().getPort();
+        }
+
+        private static int getRandomAvailablePort() {
+            try (ServerSocket socket = new ServerSocket(0)) {
+                socket.setReuseAddress(true);
+                return socket.getLocalPort();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to find a random available port", e);
+            }
+        }
+
+        static class NoResponseHandler implements HttpHandler {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                // Do nothing, effectively not sending a response
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Adds default connection timeouts to fix the https://github.com/OxalisCommunity/commons-certvalidator/issues/3